### PR TITLE
Fixing decimal entry for running times

### DIFF
--- a/stations/hitting.html
+++ b/stations/hitting.html
@@ -44,7 +44,7 @@
 
                 <div class="player_criteria">
                     <label for="hitting_baserunning">First to Third</label><br/>
-                    <input type="number" id="hitting_baserunning" name="hitting_baserunning">
+                    <input type="number" id="hitting_baserunning" name="hitting_baserunning" step=0.1>
                 </div>
 
             </div>


### PR DESCRIPTION
adding step of 0.1 instead of default of 1. We can do 0.01 if we find it necessary.
